### PR TITLE
Add support for handling invalidated PushKit tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
+# Flutter Voip Push Notification
 
+## 0.0.4
+
+- Add support for invalidating tokens
 
 ## 0.0.3
-* Rename IOSNotificationSettings to NotificationSettings and refactored example
+
+- Rename IOSNotificationSettings to NotificationSettings and refactored example
 
 ## 0.0.2
-* Add support for showing local notification, uses app delegate as push delegate
+
+- Add support for showing local notification, uses app delegate as push delegate
 
 ## 0.0.1
 
-* Initial release.
+- Initial release.

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -27,6 +27,11 @@ import flutter_voip_push_notification
         FlutterVoipPushNotificationPlugin.didReceiveIncomingPush(with: payload, forType: type.rawValue)
     }
     
+    // Handle invalidated push tokens
+    func pushRegistry(_ registry: PKPushRegistry, didInvalidatePushTokenFor type: PKPushType) {
+        FlutterVoipPushNotificationPlugin.didInvalidatePushToken(forType: type.rawValue)
+    }
+    
     // Handle incoming pushes
     func pushRegistry(_ registry: PKPushRegistry, didUpdate pushCredentials: PKPushCredentials, for type: PKPushType) {
         // Process the received push

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,7 +27,11 @@ class _MyAppState extends State<MyApp> {
     _voipPush.onTokenRefresh.listen(onToken);
 
     // do configure voip push
-    _voipPush.configure(onMessage: onMessage, onResume: onResume);
+    _voipPush.configure(
+      onMessage: onMessage,
+      onResume: onResume,
+      onInvalidToken: onInvalidToken,
+    );
   }
 
   /// Called when the device token changes
@@ -59,9 +63,20 @@ class _MyAppState extends State<MyApp> {
     return null;
   }
 
-  showLocalNotification(Map<String, dynamic> notification) {
+  /// Call to receive an PushKit invalid token
+  ///
+  /// [invalidToken] is the token that is no longer valid
+  /// Check out why a token could no longer be valid
+  /// https://stackoverflow.com/questions/46977380/voip-push-under-what-circumstances-does-didinvalidatepushtokenfortype-get-calle#47015401
+  Future<dynamic> onInvalidToken(String invalidToken) {
+    // Tell the server to remove the invalid token
+    print("received on background invalidToken: $invalidToken");
+    return null;
+  }
+
+  Future<void> showLocalNotification(Map<String, dynamic> notification) {
     String alert = notification["aps"]["alert"];
-    _voipPush.presentLocalNotification(LocalNotification(
+    return _voipPush.presentLocalNotification(LocalNotification(
       alertBody: "Hello $alert",
     ));
   }

--- a/ios/Classes/FlutterVoipPushNotificationPlugin.h
+++ b/ios/Classes/FlutterVoipPushNotificationPlugin.h
@@ -4,4 +4,5 @@
 @interface FlutterVoipPushNotificationPlugin : NSObject<FlutterPlugin>
 + (void)didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type;
 + (void)didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type;
++ (void)didInvalidatePushTokenForType:(NSString *)type;
 @end


### PR DESCRIPTION
@peerwaya I'm not sure If i should have included the cached token or not when calling invalidate token on the dart side. Perhaps I am calling invalidate token on a valid token?